### PR TITLE
Add props to social share icons and adjust their position at small and large screens

### DIFF
--- a/src/components/FacebookShareBtn.jsx
+++ b/src/components/FacebookShareBtn.jsx
@@ -1,9 +1,9 @@
 import { FacebookShareButton, FacebookIcon} from 'react-share';
 
-function FacebookShareBtn() {
+function FacebookShareBtn({borderRadius}) {
   return (
     <FacebookShareButton>
-        <FacebookIcon size={35}/>
+        <FacebookIcon size={35} borderRadius={borderRadius}/>
     </FacebookShareButton>
   )
 }

--- a/src/components/FacebookShareBtn.jsx
+++ b/src/components/FacebookShareBtn.jsx
@@ -1,8 +1,8 @@
 import { FacebookShareButton, FacebookIcon} from 'react-share';
 
-function FacebookShareBtn({borderRadius}) {
+function FacebookShareBtn({borderRadius, shareUrl}) {
   return (
-    <FacebookShareButton>
+    <FacebookShareButton url={shareUrl} title={"sub me"} quote={'hello'}>
         <FacebookIcon size={35} borderRadius={borderRadius}/>
     </FacebookShareButton>
   )

--- a/src/components/LineShareBtn.jsx
+++ b/src/components/LineShareBtn.jsx
@@ -1,8 +1,8 @@
 import { LineShareButton, LineIcon} from 'react-share';
 
-function LineShareBtn({borderRadius}) {
+function LineShareBtn({borderRadius, shareUrl}) {
   return (
-    <LineShareButton>
+    <LineShareButton url={shareUrl}>
         <LineIcon size={35} borderRadius={borderRadius}/>
     </LineShareButton>
   )

--- a/src/components/LineShareBtn.jsx
+++ b/src/components/LineShareBtn.jsx
@@ -1,9 +1,9 @@
 import { LineShareButton, LineIcon} from 'react-share';
 
-function LineShareBtn() {
+function LineShareBtn({borderRadius}) {
   return (
     <LineShareButton>
-        <LineIcon size={35}/>
+        <LineIcon size={35} borderRadius={borderRadius}/>
     </LineShareButton>
   )
 }

--- a/src/components/LinkedInShareBtn.jsx
+++ b/src/components/LinkedInShareBtn.jsx
@@ -1,9 +1,9 @@
 import { LinkedinShareButton, LinkedinIcon } from "react-share"
 
-function LinkedInShareBtn() {
+function LinkedInShareBtn({borderRadius}) {
   return (
     <LinkedinShareButton>
-        <LinkedinIcon size={35}/>
+        <LinkedinIcon size={35} borderRadius={borderRadius}/>
     </LinkedinShareButton>
   )
 }

--- a/src/components/LinkedInShareBtn.jsx
+++ b/src/components/LinkedInShareBtn.jsx
@@ -1,8 +1,8 @@
 import { LinkedinShareButton, LinkedinIcon } from "react-share"
 
-function LinkedInShareBtn({borderRadius}) {
+function LinkedInShareBtn({borderRadius, shareUrl}) {
   return (
-    <LinkedinShareButton>
+    <LinkedinShareButton url={shareUrl}>
         <LinkedinIcon size={35} borderRadius={borderRadius}/>
     </LinkedinShareButton>
   )

--- a/src/components/PinterestShareBtn.jsx
+++ b/src/components/PinterestShareBtn.jsx
@@ -1,8 +1,8 @@
 import { PinterestShareButton, PinterestIcon } from 'react-share'
 
-function PinterestShareBtn({borderRadius}) {
+function PinterestShareBtn({borderRadius, shareUrl}) {
   return (
-    <PinterestShareButton>
+    <PinterestShareButton url={shareUrl}>
         <PinterestIcon size={35} borderRadius={borderRadius}/>
     </PinterestShareButton>
   )

--- a/src/components/PinterestShareBtn.jsx
+++ b/src/components/PinterestShareBtn.jsx
@@ -1,9 +1,9 @@
 import { PinterestShareButton, PinterestIcon } from 'react-share'
 
-function PinterestShareBtn() {
+function PinterestShareBtn({borderRadius}) {
   return (
     <PinterestShareButton>
-        <PinterestIcon size={35}/>
+        <PinterestIcon size={35} borderRadius={borderRadius}/>
     </PinterestShareButton>
   )
 }

--- a/src/components/TwitterShareBtn.jsx
+++ b/src/components/TwitterShareBtn.jsx
@@ -1,9 +1,9 @@
 import { TwitterShareButton, TwitterIcon} from 'react-share';
 
-function TwitterShareBtn() {
+function TwitterShareBtn({borderRadius}) {
   return (
     <TwitterShareButton>
-        <TwitterIcon size={35}/>
+        <TwitterIcon size={35} borderRadius={borderRadius}/>
     </TwitterShareButton>
   )
 }

--- a/src/components/TwitterShareBtn.jsx
+++ b/src/components/TwitterShareBtn.jsx
@@ -1,8 +1,8 @@
 import { TwitterShareButton, TwitterIcon} from 'react-share';
 
-function TwitterShareBtn({borderRadius}) {
+function TwitterShareBtn({borderRadius, shareUrl}) {
   return (
-    <TwitterShareButton>
+    <TwitterShareButton url={shareUrl}>
         <TwitterIcon size={35} borderRadius={borderRadius}/>
     </TwitterShareButton>
   )

--- a/src/components/WhatsAppShareBtn.jsx
+++ b/src/components/WhatsAppShareBtn.jsx
@@ -1,8 +1,8 @@
 import { WhatsappShareButton, WhatsappIcon } from "react-share"
 
-function WhatsAppShareBtn({borderRadius}) {
+function WhatsAppShareBtn({borderRadius, shareUrl}) {
   return (
-    <WhatsappShareButton>
+    <WhatsappShareButton url={shareUrl}>
         <WhatsappIcon size={35} borderRadius={borderRadius}/>
     </WhatsappShareButton>
   )

--- a/src/components/WhatsAppShareBtn.jsx
+++ b/src/components/WhatsAppShareBtn.jsx
@@ -1,9 +1,9 @@
 import { WhatsappShareButton, WhatsappIcon } from "react-share"
 
-function WhatsAppShareBtn() {
+function WhatsAppShareBtn({borderRadius}) {
   return (
     <WhatsappShareButton>
-        <WhatsappIcon size={35}/>
+        <WhatsappIcon size={35} borderRadius={borderRadius}/>
     </WhatsappShareButton>
   )
 }

--- a/src/pages/Recipe.jsx
+++ b/src/pages/Recipe.jsx
@@ -18,12 +18,12 @@ function Recipe() {
   const [details, setDetails] = useState({});
   const [activeTab, setActiveTab] = useState('summary');
   const [borderRadius, setBorderRadius] = useState(15);
+  const shareUrl = 'https://dishlyst.netlify.app/';
 
   const fetchDetails = async () => {
     const data = await fetch(`https://api.spoonacular.com/recipes/${params.name}/information?apiKey=${process.env.REACT_APP_API_KEY}`);
     const detailData = await data.json();
     setDetails(detailData);
-    
   }
   
   useEffect(() => {
@@ -48,12 +48,12 @@ function Recipe() {
               <ShareIconContainer>
                 <BsShareFill/>
               </ShareIconContainer>
-              <PinterestShareBtn borderRadius={borderRadius}/>
-              <TwitterShareBtn borderRadius={borderRadius}/>
-              <FacebookShareBtn borderRadius={borderRadius}/>
-              <LineShareBtn borderRadius={borderRadius}/>
-              <LinkedInShareBtn borderRadius={borderRadius}/>
-              <WhatsAppShareBtn borderRadius={borderRadius}/>
+              <PinterestShareBtn borderRadius={borderRadius} shareUrl={shareUrl}/>
+              <TwitterShareBtn borderRadius={borderRadius} shareUrl={shareUrl}/>
+              <FacebookShareBtn borderRadius={borderRadius} shareUrl={shareUrl}/>
+              <LineShareBtn borderRadius={borderRadius} shareUrl={shareUrl}/>
+              <LinkedInShareBtn borderRadius={borderRadius} shareUrl={shareUrl}/>
+              <WhatsAppShareBtn borderRadius={borderRadius} shareUrl={shareUrl}/>
             </ShareButtonsContainer>
           </ShareContainerOuter>
 

--- a/src/pages/Recipe.jsx
+++ b/src/pages/Recipe.jsx
@@ -10,7 +10,6 @@ import LinkedInShareBtn from "../components/LinkedInShareBtn";
 import WhatsAppShareBtn from "../components/WhatsAppShareBtn";
 import { BsShare } from "react-icons/bs";
 import { BsShareFill } from "react-icons/bs";
-
 import { devices } from "../breakpoints";
 
 function Recipe() {
@@ -41,7 +40,6 @@ function Recipe() {
           
             <ShareButtonsContainer>
               <ShareIconContainer>
-                {/* <BsShare/> */}
                 <BsShareFill/>
               </ShareIconContainer>
               <PinterestShareBtn/>
@@ -99,24 +97,44 @@ function Recipe() {
 
 const ShareContainerOuter = styled.div`
   display: flex;
-  flex-direction: row-reverse;
+  flex-direction: column;
+  @media ${devices.tablet} {
+    flex-direction: row-reverse;
+  }
 ` ;
 
 const ShareIconContainer = styled.div`
+display: none;
+@media ${devices.tablet}{
+  display: block;
   background: linear-gradient(35deg, #494949, #313131);
   padding: 1rem .7rem 1rem 1rem;
   border-radius: 10px 0 0 10px;
   margin-bottom: .5rem;
+}
+
   /* z-index: -1; */
 `;
 
 const ShareButtonsContainer = styled.div`
   display: flex;
-  flex-direction: column;
-  margin-top: 2rem;
+  justify-content: space-around;
+  /* flex-direction: column; */
+  /* margin-top: 2rem; */
   /* margin-right: -.5rem; */
   /* background-color: lightgray; */
-  align-items: flex-end;
+  /* align-items: flex-end; */
+
+  @media ${devices.tablet} {
+    display: flex;
+    flex-direction: column;
+    margin-top: 2rem;
+  /* margin-right: -.5rem; */
+  /* background-color: lightgray; */
+    align-items: flex-end;
+    justify-content: flex-start;
+  }
+  
 
   &:nth-child(2){
     font-size: 1.3rem;

--- a/src/pages/Recipe.jsx
+++ b/src/pages/Recipe.jsx
@@ -98,6 +98,7 @@ function Recipe() {
 const ShareContainerOuter = styled.div`
   display: flex;
   flex-direction: column;
+  /* background-color: orange; */
   @media ${devices.tablet} {
     flex-direction: row-reverse;
   }
@@ -105,6 +106,7 @@ const ShareContainerOuter = styled.div`
 
 const ShareIconContainer = styled.div`
 display: none;
+
 @media ${devices.tablet}{
   display: block;
   background: linear-gradient(35deg, #494949, #313131);
@@ -119,10 +121,13 @@ display: none;
 const ShareButtonsContainer = styled.div`
   display: flex;
   justify-content: space-around;
+ 
+
   /* flex-direction: column; */
   /* margin-top: 2rem; */
   /* margin-right: -.5rem; */
   /* background-color: lightgray; */
+  margin-bottom: 2.5rem;
   /* align-items: flex-end; */
 
   @media ${devices.tablet} {
@@ -184,6 +189,7 @@ const DetailWrapper = styled.div`
       width: clamp(17rem, 15.8rem + 6vw, 23rem);
       border-radius: 2rem;
       margin-bottom: 2.5rem;
+      margin-bottom: 1rem;
       object-fit: cover;
       @media ${devices.tablet} {
         width: 25rem;
@@ -224,9 +230,10 @@ const ButtonContainer = styled.div`
   flex-direction: column;
   justify-content: space-around;
   width: 11rem;
-  height: 11rem;
+  
   @media ${devices.tablet} {
-    margin-left: 5rem;
+    margin-left: 3rem;
+    height: 11rem;
   }
 `;
 
@@ -235,6 +242,7 @@ display: flex;
 flex-direction: column;
 align-items: center;
 justify-content: center;
+/* background-color: green; */
   @media ${devices.tablet} {
     display: flex;
     justify-content: center;

--- a/src/pages/Recipe.jsx
+++ b/src/pages/Recipe.jsx
@@ -17,6 +17,8 @@ function Recipe() {
   let params = useParams();
   const [details, setDetails] = useState({});
   const [activeTab, setActiveTab] = useState('summary');
+  const [borderRadius, setBorderRadius] = useState(15);
+
   const fetchDetails = async () => {
     const data = await fetch(`https://api.spoonacular.com/recipes/${params.name}/information?apiKey=${process.env.REACT_APP_API_KEY}`);
     const detailData = await data.json();
@@ -27,6 +29,10 @@ function Recipe() {
   useEffect(() => {
     fetchDetails();
   }, [params.name]);
+  
+  useEffect(() => {
+      {window.screen.width < 760 ? setBorderRadius(15) : setBorderRadius(0)}
+  }, []);
 
   // console.log(details)
 
@@ -42,12 +48,12 @@ function Recipe() {
               <ShareIconContainer>
                 <BsShareFill/>
               </ShareIconContainer>
-              <PinterestShareBtn/>
-              <TwitterShareBtn/>
-              <FacebookShareBtn/>
-              <LineShareBtn/>
-              <LinkedInShareBtn/>
-              <WhatsAppShareBtn/>
+              <PinterestShareBtn borderRadius={borderRadius}/>
+              <TwitterShareBtn borderRadius={borderRadius}/>
+              <FacebookShareBtn borderRadius={borderRadius}/>
+              <LineShareBtn borderRadius={borderRadius}/>
+              <LinkedInShareBtn borderRadius={borderRadius}/>
+              <WhatsAppShareBtn borderRadius={borderRadius}/>
             </ShareButtonsContainer>
           </ShareContainerOuter>
 


### PR DESCRIPTION
## Summary
Fixes issue: #3 

Add border radius and url props to all social share icons and adjust social share buttons position at different screen sizes.

## Details
Dynamically add / remove border radius on social share buttons based on screen size - add border radius < 760px, remove border radius >= 760px. Adjust the position of the social share icons: <760px below Recipe image, >= 760px next to Recipe image

### Why?
The url prop tells the button what site to share on the social media app. I passed in the dishlyst homepage url, so this url will be shared to all social media apps.

### How?
I passed shareUrl and borderRadius props to all the social share buttons in Recipe, then destructured the props in each social share button component and passed the props to the returned jsx. Doing it this way avoids unnecessary repetition as the url and border radius values are the same for all buttons.

## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
