### PR TITLE
relocate toast notifications from top-right to top-left of UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ function App() {
         <BrowserRouter>
         <FavoritesProvider>
           <ToastContainer 
-            position="top-right"
+            position="top-left"
             autoClose={500}
             hideProgressBar
             newestOnTop={false}


### PR DESCRIPTION
## Summary
Fixes issue #19 
## Details

### Why?
The UI in the top right is cluttered and the toast notifications cover the favorite button and favorite count.
### How?
Redefine the position attribute on the Toastcontainer element
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
