### PR TITLE
prevent add to favorites button from loading before api call is finished and data is ready

### DIFF
--- a/src/pages/Recipe.jsx
+++ b/src/pages/Recipe.jsx
@@ -34,7 +34,7 @@ function Recipe() {
       {window.screen.width < 760 ? setBorderRadius(15) : setBorderRadius(0)}
   }, []);
 
-  // console.log(details)
+  console.log(Object.keys(details), 'details')
 
   return (
     <DetailWrapper>
@@ -57,9 +57,9 @@ function Recipe() {
             </ShareButtonsContainer>
           </ShareContainerOuter>
 
+          
           <ButtonContainer>
-           
-           <AddToFavorites details={details}/>
+           {Object.keys(details).length !== 0 && <AddToFavorites details={details}/>}
             <Button 
               className={activeTab === 'summary' ? 'active' : ''}
               onClick={() => setActiveTab('summary')}>Nutrition Info


### PR DESCRIPTION


## Summary
Fixes issue #2 
## Details

### Why?
If the AddToFavorites button in the Recipe.jsx component is clicked before the API data is loaded, it adds an empty item to the favorites array, which is displayed as an empty image outline. This behavior is buggy.
### How?
In Recipe, conditionally render AddToFavorites based on whether API data has loaded or not. Use Object.keys() method on the details state to check its length. If it is 0, meaning it's empty, then the API data hasn't loaded and the AddToFavorites button will not load. If its length is greater than 0, then the API data has loaded and the AddToFavorites button can be used. 
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
