### PR TITLE
add shareUrl state. call setShareUrl in fetchDetails and set to correct page url.

### DIFF
--- a/src/pages/Recipe.jsx
+++ b/src/pages/Recipe.jsx
@@ -18,16 +18,19 @@ function Recipe() {
   const [details, setDetails] = useState({});
   const [activeTab, setActiveTab] = useState('summary');
   const [borderRadius, setBorderRadius] = useState(15);
-  const shareUrl = window.location.href;
+  const [shareUrl, setShareUrl] = useState('');
+  // const shareUrl = window.location.href;
   
 
   const fetchDetails = async () => {
     const data = await fetch(`https://api.spoonacular.com/recipes/${params.name}/information?apiKey=${process.env.REACT_APP_API_KEY}`);
     const detailData = await data.json();
     setDetails(detailData);
+    const url = `https://dishlyst.netlify.app/recipe/${detailData.id}`;
+    setShareUrl(url);
   }
   
-  
+
   useEffect(() => {
     fetchDetails();
   }, [params.name]);
@@ -36,9 +39,6 @@ function Recipe() {
       {window.screen.width < 760 ? setBorderRadius(15) : setBorderRadius(0)}
   }, []);
 
-  // console.log(Object.keys(details), 'details')
-// console.log(shareUrl+details.id, 'test url')
-console.log(window.location.href)
   return (
     <DetailWrapper>
         <h2>{details.title}</h2>


### PR DESCRIPTION
## Summary
Fixes issue #24 
## Details

### Why?
Previously setShare url wasn't defined properly which caused routing issues.
### How?
Make shareUrl state and default to an empty string. In fetchDetails, declare 'url' variable and set to hardcoded url interpolated with 'detailData.id' at the end. Call setShareUrl and pass in url. 
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
