### PR TITLE
Conditionally render either splide or mobile layout based on screen size

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import FavoriteBtn from "./components/FavoriteBtn";
 import { FavoritesProvider } from "./components/FavoritesProvider";
 
 import { ToastContainer, Flip } from 'react-toastify';
+import ScreenWidthProvider from "./components/ScreenWidthContext";
 
 
 function App() {
@@ -14,6 +15,7 @@ function App() {
     <div className="App">
       
         <BrowserRouter>
+        <ScreenWidthProvider>
         <FavoritesProvider>
           <ToastContainer 
             position="top-left"
@@ -36,6 +38,7 @@ function App() {
           <Category/>
           <Pages />
           </FavoritesProvider>
+          </ScreenWidthProvider>
         </BrowserRouter>
       
     </div>

--- a/src/SharedStyles.js
+++ b/src/SharedStyles.js
@@ -70,6 +70,7 @@ const Card = styled.div`
 
 const SplideCard = styled(Card)`
   width: 25rem;
+  margin: 0 0 0 1rem;
 `;
 
 const Gradient = styled.div`

--- a/src/SharedStyles.js
+++ b/src/SharedStyles.js
@@ -23,6 +23,7 @@ const WrapperSecondary = styled(Wrapper)`
 const Card = styled.div`
   height: 15rem;
   width: 15rem;
+  width: 15rem;
   border-radius: 2rem;
   overflow: hidden;
   position: relative;
@@ -30,11 +31,12 @@ const Card = styled.div`
 
   @media ${devices.tablet} {
     width: 45%;
+    width: 50rem;
   }
 
   @media ${devices.laptop} {
     width: 23rem;
-    width: 30%;
+    width: 30%; 
     height: 20rem;
   }
 
@@ -66,6 +68,10 @@ const Card = styled.div`
   }
 `;
 
+const SplideCard = styled(Card)`
+  width: 25rem;
+`;
+
 const Gradient = styled.div`
   z-index: 1;
   position: absolute;
@@ -92,6 +98,6 @@ const MobileContainer = styled.div`
   }
 `;
 
-export { Wrapper, WrapperSecondary, Card, Gradient, MobileContainer};
+export { Wrapper, WrapperSecondary, Card, Gradient, MobileContainer, SplideCard};
 
 

--- a/src/SharedStyles.js
+++ b/src/SharedStyles.js
@@ -36,7 +36,6 @@ const Card = styled.div`
 
   @media ${devices.tablet} {
     width: 45%;
-    width: 50rem;
   }
 
   @media ${devices.laptop} {

--- a/src/SharedStyles.js
+++ b/src/SharedStyles.js
@@ -8,6 +8,11 @@ flex-direction: column;
 justify-content: space-around;
 text-align: center;
 align-items: center;
+
+@media ${devices.tablet} {
+  align-items: normal;
+}
+
 `;
 
 const WrapperSecondary = styled(Wrapper)`
@@ -23,7 +28,7 @@ const WrapperSecondary = styled(Wrapper)`
 const Card = styled.div`
   height: 15rem;
   width: 15rem;
-  width: 15rem;
+  /* width: 15rem; */
   border-radius: 2rem;
   overflow: hidden;
   position: relative;
@@ -65,12 +70,17 @@ const Card = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
+
+    @media ${devices.tablet} {
+      font-size: 1.2rem;
+      bottom: -.5rem;
+    }
   }
 `;
 
 const SplideCard = styled(Card)`
   width: 25rem;
-  margin: 0 0 0 1rem;
+  margin-left: 3.5rem;
 `;
 
 const Gradient = styled.div`

--- a/src/components/Fingerfood.jsx
+++ b/src/components/Fingerfood.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Splide, SplideSlide } from "@splidejs/react-splide"
 import '@splidejs/splide/dist/css/splide.min.css';
 import { Link } from "react-router-dom";
-import { Wrapper, Card, Gradient, MobileContainer } from "../SharedStyles.js";
+import { Wrapper, Card, Gradient, MobileContainer, SplideCard } from "../SharedStyles.js";
 import FavoritesToggleBtn from "./FavoritesToggleBtn";
 import { useFavoritesContext } from '../components/FavoritesProvider';
 
@@ -37,7 +37,7 @@ function Fingerfood() {
             <Wrapper>
   
               <h3>Fingerfood</h3>
-  
+{/*   
               <MobileContainer>
               {fingerfood.map((recipe) => {
                   return(
@@ -53,29 +53,29 @@ function Fingerfood() {
                       </Card>
                   );
                 })}
-              </MobileContainer>
+              </MobileContainer> */}
   
-              {/* <Splide options={{
-                perPage: 3, 
+              <Splide options={{
+                perPage: 4, 
                 arrows: false, 
                 pagination: false, 
                 drag: 'free', 
-                gap: '5rem'
+                gap: '-3rem'
               }}>
-                {veggie.map((recipe) => {
+                {fingerfood.map((recipe) => {
                   return(
                     <SplideSlide key={recipe.id}>
-                      <Card>
-                        <Link to={'/recipe/' + recipe.id}>
-                          <p>{recipe.title}</p>
-                          <img src={recipe.image} alt={recipe.title} />
-                          <Gradient/>
-                        </Link>
-                      </Card>
-                    </SplideSlide>
+                    <SplideCard>
+                      <Link to={'/recipe' + recipe.id}>
+                        <h4>{recipe.title}</h4>
+                        <img src={recipe.image} alt={recipe.title} />
+                        <Gradient/>
+                      </Link>
+                    </SplideCard>
+                  </SplideSlide>
                   );
                 })}
-              </Splide> */}
+              </Splide>
             </Wrapper>
       </div>
     );

--- a/src/components/Fingerfood.jsx
+++ b/src/components/Fingerfood.jsx
@@ -5,15 +5,19 @@ import { Link } from "react-router-dom";
 import { Wrapper, Card, Gradient, MobileContainer, SplideCard } from "../SharedStyles.js";
 import FavoritesToggleBtn from "./FavoritesToggleBtn";
 import { useFavoritesContext } from '../components/FavoritesProvider';
+import { useScreenWidthContext } from "./ScreenWidthContext.jsx";
 
 function Fingerfood() {
 
     const [fingerfood, setFingerfood] = useState([]);
 
+    const {screenWidth, handleWindowResize} = useScreenWidthContext();
+    
     const { favoritesChecker, removeFromFavorites, addToFavorites } = useFavoritesContext();
 
     useEffect(() => {
         getFingerfood();
+        handleWindowResize();
     }, []);
 
     const getFingerfood = async () => {
@@ -37,8 +41,8 @@ function Fingerfood() {
             <Wrapper>
   
               <h3>Fingerfood</h3>
-{/*   
-              <MobileContainer>
+  
+              {screenWidth < 1280 && <MobileContainer>
               {fingerfood.map((recipe) => {
                   return(
                       <Card key={recipe.id}>
@@ -53,9 +57,9 @@ function Fingerfood() {
                       </Card>
                   );
                 })}
-              </MobileContainer> */}
+              </MobileContainer>}
   
-              <Splide options={{
+              {screenWidth >= 1280 && <Splide options={{
                 perPage: 4, 
                 arrows: false, 
                 pagination: false, 
@@ -75,7 +79,7 @@ function Fingerfood() {
                   </SplideSlide>
                   );
                 })}
-              </Splide>
+              </Splide>}
             </Wrapper>
       </div>
     );

--- a/src/components/GlutenFree.jsx
+++ b/src/components/GlutenFree.jsx
@@ -5,15 +5,19 @@ import { Link } from "react-router-dom";
 import { Wrapper, Card, Gradient, MobileContainer, SplideCard } from "../SharedStyles.js";
 import FavoritesToggleBtn from "./FavoritesToggleBtn";
 import { useFavoritesContext } from '../components/FavoritesProvider';
+import { useScreenWidthContext } from "./ScreenWidthContext.jsx";
 
 function GlutenFree() {
 
     const [glutenFree, setGlutenFree] = useState([]);
 
+    const {screenWidth, handleWindowResize} = useScreenWidthContext();
+
     const { favoritesChecker, removeFromFavorites, addToFavorites } = useFavoritesContext();
 
     useEffect(() => {
         getGlutenFree();
+        handleWindowResize();
     }, []);
 
     const getGlutenFree = async () => {
@@ -38,7 +42,7 @@ function GlutenFree() {
   
               <h3>Gluten Free</h3>
   
-              {/* <MobileContainer>
+              { screenWidth < 1280 && <MobileContainer>
               {glutenFree.map((recipe) => {
                   return(
                       <Card key={recipe.id}>
@@ -53,9 +57,9 @@ function GlutenFree() {
                       </Card>
                   );
                 })}
-              </MobileContainer> */}
+              </MobileContainer> }
   
-              <Splide options={{
+             { screenWidth >= 1280 && <Splide options={{
                 perPage: 4, 
                 arrows: false, 
                 pagination: false, 
@@ -75,7 +79,7 @@ function GlutenFree() {
                   </SplideSlide>
                   );
                 })}
-              </Splide>
+              </Splide> }
             </Wrapper>
       </div>
     );

--- a/src/components/GlutenFree.jsx
+++ b/src/components/GlutenFree.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Splide, SplideSlide } from "@splidejs/react-splide"
 import '@splidejs/splide/dist/css/splide.min.css';
 import { Link } from "react-router-dom";
-import { Wrapper, Card, Gradient, MobileContainer } from "../SharedStyles.js";
+import { Wrapper, Card, Gradient, MobileContainer, SplideCard } from "../SharedStyles.js";
 import FavoritesToggleBtn from "./FavoritesToggleBtn";
 import { useFavoritesContext } from '../components/FavoritesProvider';
 
@@ -38,7 +38,7 @@ function GlutenFree() {
   
               <h3>Gluten Free</h3>
   
-              <MobileContainer>
+              {/* <MobileContainer>
               {glutenFree.map((recipe) => {
                   return(
                       <Card key={recipe.id}>
@@ -53,29 +53,29 @@ function GlutenFree() {
                       </Card>
                   );
                 })}
-              </MobileContainer>
+              </MobileContainer> */}
   
-              {/* <Splide options={{
-                perPage: 3, 
+              <Splide options={{
+                perPage: 4, 
                 arrows: false, 
                 pagination: false, 
                 drag: 'free', 
-                gap: '5rem'
+                gap: '-3rem'
               }}>
-                {veggie.map((recipe) => {
+                {glutenFree.map((recipe) => {
                   return(
-                    <SplideSlide key={recipe.id}>
-                      <Card>
-                        <Link to={'/recipe/' + recipe.id}>
-                          <p>{recipe.title}</p>
-                          <img src={recipe.image} alt={recipe.title} />
-                          <Gradient/>
-                        </Link>
-                      </Card>
-                    </SplideSlide>
+                   <SplideSlide key={recipe.id}>
+                    <SplideCard>
+                      <Link to={'/recipe' + recipe.id}>
+                        <h4>{recipe.title}</h4>
+                        <img src={recipe.image} alt={recipe.title} />
+                        <Gradient/>
+                      </Link>
+                    </SplideCard>
+                  </SplideSlide>
                   );
                 })}
-              </Splide> */}
+              </Splide>
             </Wrapper>
       </div>
     );

--- a/src/components/LowCarb.jsx
+++ b/src/components/LowCarb.jsx
@@ -5,15 +5,19 @@ import { Link } from "react-router-dom";
 import { Wrapper, Card, Gradient, MobileContainer, SplideCard} from "../SharedStyles.js";
 import FavoritesToggleBtn from "./FavoritesToggleBtn";
 import { useFavoritesContext } from '../components/FavoritesProvider';
+import {useScreenWidthContext} from "./ScreenWidthContext.jsx";
 
 function LowCarb() {
 
     const [lowCarb, setLowCarb] = useState([]);
 
+    const {screenWidth, handleWindowResize} = useScreenWidthContext();
+    
     const { favoritesChecker, removeFromFavorites, addToFavorites } = useFavoritesContext();
 
     useEffect(() => {
         getLowCarb();
+        handleWindowResize();
     }, []);
 
     const getLowCarb = async () => {
@@ -37,8 +41,8 @@ function LowCarb() {
             <Wrapper>
   
               <h3>Low Carb</h3>
-{/*   
-              <MobileContainer>
+            
+            { screenWidth < 1280 && <MobileContainer>
               {lowCarb.map((recipe) => {
                   return(
                       <Card key={recipe.id}>
@@ -53,9 +57,9 @@ function LowCarb() {
                       </Card>
                   );
                 })}
-              </MobileContainer> */}
+              </MobileContainer>}
   
-              <Splide options={{
+              {screenWidth >= 1280 && <Splide options={{
                 perPage: 4, 
                 arrows: false, 
                 pagination: false, 
@@ -75,7 +79,7 @@ function LowCarb() {
                   </SplideSlide>
                   );
                 })}
-              </Splide>
+              </Splide>}
             </Wrapper>
       </div>
     );

--- a/src/components/LowCarb.jsx
+++ b/src/components/LowCarb.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Splide, SplideSlide } from "@splidejs/react-splide"
 import '@splidejs/splide/dist/css/splide.min.css';
 import { Link } from "react-router-dom";
-import { Wrapper, Card, Gradient, MobileContainer } from "../SharedStyles.js";
+import { Wrapper, Card, Gradient, MobileContainer, SplideCard} from "../SharedStyles.js";
 import FavoritesToggleBtn from "./FavoritesToggleBtn";
 import { useFavoritesContext } from '../components/FavoritesProvider';
 
@@ -37,7 +37,7 @@ function LowCarb() {
             <Wrapper>
   
               <h3>Low Carb</h3>
-  
+{/*   
               <MobileContainer>
               {lowCarb.map((recipe) => {
                   return(
@@ -53,29 +53,29 @@ function LowCarb() {
                       </Card>
                   );
                 })}
-              </MobileContainer>
+              </MobileContainer> */}
   
-              {/* <Splide options={{
-                perPage: 3, 
+              <Splide options={{
+                perPage: 4, 
                 arrows: false, 
                 pagination: false, 
                 drag: 'free', 
-                gap: '5rem'
+                gap: '-3rem'
               }}>
-                {veggie.map((recipe) => {
+                {lowCarb.map((recipe) => {
                   return(
                     <SplideSlide key={recipe.id}>
-                      <Card>
-                        <Link to={'/recipe/' + recipe.id}>
-                          <p>{recipe.title}</p>
-                          <img src={recipe.image} alt={recipe.title} />
-                          <Gradient/>
-                        </Link>
-                      </Card>
-                    </SplideSlide>
+                    <SplideCard>
+                      <Link to={'/recipe' + recipe.id}>
+                        <h4>{recipe.title}</h4>
+                        <img src={recipe.image} alt={recipe.title} />
+                        <Gradient/>
+                      </Link>
+                    </SplideCard>
+                  </SplideSlide>
                   );
                 })}
-              </Splide> */}
+              </Splide>
             </Wrapper>
       </div>
     );

--- a/src/components/Popular.jsx
+++ b/src/components/Popular.jsx
@@ -62,14 +62,14 @@ function Popular() {
               arrows: false, 
               pagination: false, 
               drag: 'free', 
-              gap: '5rem'
+              // gap: '-10rem'
             }}>
               {popular.map((recipe) => {
                 return(
                   <SplideSlide key={recipe.id}>
                     <SplideCard>
                       <Link to={'/recipe' + recipe.id}>
-                        <p>{recipe.title}</p>
+                        <h4>{recipe.title}</h4>
                         <img src={recipe.image} alt={recipe.title} />
                         <Gradient/>
                       </Link>

--- a/src/components/Popular.jsx
+++ b/src/components/Popular.jsx
@@ -8,24 +8,23 @@ import { useFavoritesContext } from '../components/FavoritesProvider';
 
 
 function Popular() {
-
     const [popular, setPopular] = useState([]);
-    const [screenWidth, setScreenWidth] = useState(window.innerWidth);
+    // const [screenWidth, setScreenWidth] = useState(window.innerWidth);
 
-    useEffect(() => {
-      const handleWindowResize = () => {
-        setScreenWidth(window.innerWidth)
-        console.log(screenWidth, 'width')
-      };
+    // useEffect(() => {
+    //   const handleWindowResize = () => {
+    //     setScreenWidth(window.innerWidth)
+    //     console.log(screenWidth, 'width')
+    //   };
 
-      window.addEventListener('resize', handleWindowResize);
+    //   window.addEventListener('resize', handleWindowResize);
 
-      return () => {
-        window.removeEventListener('resize', handleWindowResize);
-      };
-    }, []) 
+    //   return () => {
+    //     window.removeEventListener('resize', handleWindowResize);
+    //   };
+    // }, []) 
 
-    console.log(screenWidth, 'width')
+    // console.log(screenWidth, 'width')
        
     const { favoritesChecker, removeFromFavorites, addToFavorites } = useFavoritesContext();
     
@@ -55,8 +54,8 @@ function Popular() {
       <div>
           <Wrapper>
             <h3>Popular Picks</h3>
-
-            {/* { window.location.innerWidth < 1280 && <MobileContainer>
+{
+            <MobileContainer>
             {popular.map((recipe) => {
                 return(
                     <Card key={recipe.id}>
@@ -71,9 +70,9 @@ function Popular() {
                     </Card>
                 );
               })}
-            </MobileContainer> } */}
+            </MobileContainer> }
 
-           <Splide options={{
+           { <Splide options={{
               perPage: 4, 
               arrows: false, 
               pagination: false, 
@@ -93,7 +92,7 @@ function Popular() {
                   </SplideSlide>
                 );
               })}
-            </Splide>
+            </Splide> }
           </Wrapper>
     </div>
   )

--- a/src/components/Popular.jsx
+++ b/src/components/Popular.jsx
@@ -5,31 +5,20 @@ import { Link } from "react-router-dom";
 import { Wrapper, Card, Gradient, MobileContainer, SplideCard } from "../SharedStyles.js";
 import FavoritesToggleBtn from "./FavoritesToggleBtn";
 import { useFavoritesContext } from '../components/FavoritesProvider';
+import { useScreenWidthContext } from "./ScreenWidthContext.jsx";
 
 
 function Popular() {
     const [popular, setPopular] = useState([]);
-    // const [screenWidth, setScreenWidth] = useState(window.innerWidth);
+    const {screenWidth, handleWindowResize} = useScreenWidthContext();
 
-    // useEffect(() => {
-    //   const handleWindowResize = () => {
-    //     setScreenWidth(window.innerWidth)
-    //     console.log(screenWidth, 'width')
-    //   };
-
-    //   window.addEventListener('resize', handleWindowResize);
-
-    //   return () => {
-    //     window.removeEventListener('resize', handleWindowResize);
-    //   };
-    // }, []) 
-
-    // console.log(screenWidth, 'width')
+    // console.log(screenWidth > 1000, 'width context')
        
     const { favoritesChecker, removeFromFavorites, addToFavorites } = useFavoritesContext();
     
     useEffect(() => {
             getPopular();
+            handleWindowResize();
         }, []);
 
         
@@ -54,7 +43,7 @@ function Popular() {
       <div>
           <Wrapper>
             <h3>Popular Picks</h3>
-{
+{screenWidth < 1280 &&
             <MobileContainer>
             {popular.map((recipe) => {
                 return(
@@ -72,7 +61,7 @@ function Popular() {
               })}
             </MobileContainer> }
 
-           { <Splide options={{
+           {screenWidth >= 1280 && <Splide options={{
               perPage: 4, 
               arrows: false, 
               pagination: false, 

--- a/src/components/Popular.jsx
+++ b/src/components/Popular.jsx
@@ -10,7 +10,23 @@ import { useFavoritesContext } from '../components/FavoritesProvider';
 function Popular() {
 
     const [popular, setPopular] = useState([]);
-    
+    const [screenWidth, setScreenWidth] = useState(window.innerWidth);
+
+    useEffect(() => {
+      const handleWindowResize = () => {
+        setScreenWidth(window.innerWidth)
+        console.log(screenWidth, 'width')
+      };
+
+      window.addEventListener('resize', handleWindowResize);
+
+      return () => {
+        window.removeEventListener('resize', handleWindowResize);
+      };
+    }, []) 
+
+    console.log(screenWidth, 'width')
+       
     const { favoritesChecker, removeFromFavorites, addToFavorites } = useFavoritesContext();
     
     useEffect(() => {
@@ -82,7 +98,6 @@ function Popular() {
     </div>
   )
 }
-
 
 
 export default Popular;

--- a/src/components/Popular.jsx
+++ b/src/components/Popular.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Splide, SplideSlide } from "@splidejs/react-splide"
 import '@splidejs/splide/dist/css/splide.min.css';
 import { Link } from "react-router-dom";
-import { Wrapper, Card, Gradient, MobileContainer } from "../SharedStyles.js";
+import { Wrapper, Card, Gradient, MobileContainer, SplideCard } from "../SharedStyles.js";
 import FavoritesToggleBtn from "./FavoritesToggleBtn";
 import { useFavoritesContext } from '../components/FavoritesProvider';
 
@@ -40,7 +40,7 @@ function Popular() {
           <Wrapper>
             <h3>Popular Picks</h3>
 
-            <MobileContainer>
+            {/* { window.location.innerWidth < 1280 && <MobileContainer>
             {popular.map((recipe) => {
                 return(
                     <Card key={recipe.id}>
@@ -55,9 +55,9 @@ function Popular() {
                     </Card>
                 );
               })}
-            </MobileContainer>
+            </MobileContainer> } */}
 
-            {/* <Splide options={{
+           <Splide options={{
               perPage: 4, 
               arrows: false, 
               pagination: false, 
@@ -67,17 +67,17 @@ function Popular() {
               {popular.map((recipe) => {
                 return(
                   <SplideSlide key={recipe.id}>
-                    <Card>
+                    <SplideCard>
                       <Link to={'/recipe' + recipe.id}>
                         <p>{recipe.title}</p>
                         <img src={recipe.image} alt={recipe.title} />
                         <Gradient/>
                       </Link>
-                    </Card>
+                    </SplideCard>
                   </SplideSlide>
                 );
               })}
-            </Splide> */}
+            </Splide>
           </Wrapper>
     </div>
   )

--- a/src/components/Popular.jsx
+++ b/src/components/Popular.jsx
@@ -62,7 +62,7 @@ function Popular() {
               arrows: false, 
               pagination: false, 
               drag: 'free', 
-              // gap: '-10rem'
+              gap: '-3rem'
             }}>
               {popular.map((recipe) => {
                 return(

--- a/src/components/ScreenWidthContext.jsx
+++ b/src/components/ScreenWidthContext.jsx
@@ -5,7 +5,9 @@ const ScreenWidthContext = createContext(null);
 
 export const useScreenWidthContext = () => {
   const context = useContext(ScreenWidthContext);
-
+  if(context === undefined) {
+    throw new Error('ScreenWidthContext must be within ScreenWidthContextProvider')
+  }
   return context;
 }
 
@@ -13,21 +15,16 @@ const ScreenWidthProvider = ({children}) => {
 
     const [screenWidth, setScreenWidth] = useState(window.innerWidth);
 
-    useEffect(() => {
+  
       const handleWindowResize = () => {
         setScreenWidth(window.innerWidth)
-        console.log(screenWidth, 'width')
-      };
 
       window.addEventListener('resize', handleWindowResize);
 
       return () => {
         window.removeEventListener('resize', handleWindowResize);
       };
-    }, []) 
-
-    console.log(screenWidth, 'width')
-
+    }
 
     return (
         <ScreenWidthContext.Provider value={{screenWidth, handleWindowResize}}>

--- a/src/components/ScreenWidthContext.jsx
+++ b/src/components/ScreenWidthContext.jsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useState, useEffect } from "react";
+
+
+const ScreenWidthContext = createContext(null);
+
+export const useScreenWidthContext = () => {
+  const context = useContext(ScreenWidthContext);
+
+  return context;
+}
+
+const ScreenWidthProvider = ({children}) => {
+
+    const [screenWidth, setScreenWidth] = useState(window.innerWidth);
+
+    useEffect(() => {
+      const handleWindowResize = () => {
+        setScreenWidth(window.innerWidth)
+        console.log(screenWidth, 'width')
+      };
+
+      window.addEventListener('resize', handleWindowResize);
+
+      return () => {
+        window.removeEventListener('resize', handleWindowResize);
+      };
+    }, []) 
+
+    console.log(screenWidth, 'width')
+
+
+    return (
+        <ScreenWidthContext.Provider value={{screenWidth, handleWindowResize}}>
+            {children}
+        </ScreenWidthContext.Provider>
+    )
+
+}
+
+export default ScreenWidthProvider;

--- a/src/components/Veggie.jsx
+++ b/src/components/Veggie.jsx
@@ -10,6 +10,8 @@ import { useFavoritesContext } from '../components/FavoritesProvider';
 
 import FavoritesToggleBtn from "./FavoritesToggleBtn";
 
+import { useScreenWidthContext } from "./ScreenWidthContext";
+
 
 
 
@@ -18,10 +20,13 @@ function Veggie() {
 
   const [veggie, setVeggie] = useState([]);
 
+  const {screenWidth, handleWindowResize} = useScreenWidthContext();
+
   const { favorites, addToFavorites, removeFromFavorites, favoritesChecker } = useFavoritesContext();
   
   useEffect(() => {
           getVeggie();
+          handleWindowResize();
       }, []);
 
   const getVeggie = async () => {
@@ -48,7 +53,7 @@ function Veggie() {
 
             <h3>Vegetarian Picks</h3>
 
-            {/* <MobileContainer>
+           {screenWidth < 1280  && <MobileContainer>
             {veggie.map((recipe) => {
                 return(
                     <Card key={recipe.id}>
@@ -63,9 +68,9 @@ function Veggie() {
                     </Card>
                 );
               })}
-            </MobileContainer> */}
+            </MobileContainer> }
 
-            <Splide options={{
+            { screenWidth >= 1280  && <Splide options={{
               perPage: 4, 
               arrows: false, 
               pagination: false, 
@@ -85,7 +90,7 @@ function Veggie() {
                   </SplideSlide>
                 );
               })}
-            </Splide>
+            </Splide> }
           </Wrapper>
     </div>
   );

--- a/src/components/Veggie.jsx
+++ b/src/components/Veggie.jsx
@@ -4,7 +4,7 @@ import '@splidejs/splide/dist/css/splide.min.css';
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { devices } from "../breakpoints";
-import { Wrapper, Card, Gradient, MobileContainer } from "../SharedStyles.js";
+import { Wrapper, Card, Gradient, MobileContainer, SplideCard } from "../SharedStyles.js";
 import ShowNew from "./ShowNew";
 import { useFavoritesContext } from '../components/FavoritesProvider';
 
@@ -48,7 +48,7 @@ function Veggie() {
 
             <h3>Vegetarian Picks</h3>
 
-            <MobileContainer>
+            {/* <MobileContainer>
             {veggie.map((recipe) => {
                 return(
                     <Card key={recipe.id}>
@@ -63,29 +63,29 @@ function Veggie() {
                     </Card>
                 );
               })}
-            </MobileContainer>
+            </MobileContainer> */}
 
-            {/* <Splide options={{
-              perPage: 3, 
+            <Splide options={{
+              perPage: 4, 
               arrows: false, 
               pagination: false, 
               drag: 'free', 
-              gap: '5rem'
+              gap: '-3rem'
             }}>
               {veggie.map((recipe) => {
                 return(
                   <SplideSlide key={recipe.id}>
-                    <Card>
+                    <SplideCard>
                       <Link to={'/recipe/' + recipe.id}>
-                        <p>{recipe.title}</p>
+                        <h4>{recipe.title}</h4>
                         <img src={recipe.image} alt={recipe.title} />
                         <Gradient/>
                       </Link>
-                    </Card>
+                    </SplideCard>
                   </SplideSlide>
                 );
               })}
-            </Splide> */}
+            </Splide>
           </Wrapper>
     </div>
   );


### PR DESCRIPTION
## Summary
Fixes issue #7 
## Details

### Why?
Smaller screens should have a grid or flex column layout, while larger screens should have a splide slider to streamline UI.
### How?
- Using window.innerWidth works for conditional rendering, but it does not update when the screen is resized, which is necessary. 
- In Popular, Veggie, LowCarb, GlutenFree and Fingerfood, return two jsx blocks: mobile container, and splide. 
- Make a ScreenWidthContext to handle screenWidth state and make it accessible throughout the app and define a handleWindowResize function to return the size of the screen as a number every time it changes and update the screenWidth state to this number; thereby constantly keeping track of all screen size changes. Define useScreenWidth custom hook to consume context. 
-  In  Popular, Veggie, LowCarb, GlutenFree and Fingerfood, destructure screenWidth and handleWindowResize from useScreenWidthContext custom hook. 
- Call handleWindowResize in useEffect.
- Conditionally render mobileContainer when screenWidth is < 1280 and Splide when screenWidth is >= 1280.
## Additional Information

## Checks
- [x] Did you reference the issue? 
- [x] Does this commit follow SRP? 
